### PR TITLE
Shellcheck: Remove file extension based explicit language flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -460,16 +460,6 @@
               "capabilities": [],
               "command": [
                 "shellcheck",
-                [
-                  "$bash",
-                  "--shell",
-                  "bash"
-                ],
-                [
-                  "!$bash",
-                  "--shell",
-                  "sh"
-                ],
                 "--format",
                 "json",
                 "--enable",


### PR DESCRIPTION
Shellcheck can detect language based on shebang in the first line. Setting this explicitly based on file extension causes issues with bash scripts that use .sh as their extension.

Fixes #4 