### PR TITLE
Added .yaml-lint.yml to yamllint config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -771,7 +771,8 @@
               "configFiles": [
                 ".yamllint.yml",
                 ".yamllint.yaml",
-                ".yamllint"
+                ".yamllint",
+                ".yaml-lint.yml"
               ],
               "enabled": true,
               "languages": [


### PR DESCRIPTION
As detailed in #35 it would be great if we could add `.yaml-lint.yml` as a supported yamllint config file as it is the default for the [GitHub superlinter](https://github.com/super-linter/super-linter).